### PR TITLE
Allow for Private HF_Lora URLs with Query Params for Auth

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -239,7 +239,7 @@ class Predictor(BasePredictor):
                     if "weight_name" not in parsed_query_params:
                         # Take weight name from last part of path
                         parsed_query_params["weight_name"] = hf_lora_parsed.path.split('/')[-1]
-                    print(f"HuggingFace slug from URL: {huggingface_slug}, weight name: {parsed_query_params["weight_name"]}")
+                    print(f"HuggingFace slug from URL: {huggingface_slug}, weight name: {parsed_query_params['weight_name']}")
                     pipe.load_lora_weights(huggingface_slug, **parsed_query_params)
                 # Check for Civitai URL
                 elif re.match(r"^https?://civitai.com/api/download/models/[0-9]+\?type=Model&format=SafeTensor", hf_lora):

--- a/predict.py
+++ b/predict.py
@@ -239,6 +239,8 @@ class Predictor(BasePredictor):
                     if "weight_name" not in parsed_query_params:
                         # Take weight name from last part of path
                         parsed_query_params["weight_name"] = hf_lora_parsed.path.split('/')[-1]
+                    # Convert list values by taking the first of each
+                    parsed_query_params = {k: (v[0] if isinstance(v, list) and v else v) for k, v in parsed_query_params.items()}
                     print(f"HuggingFace slug from URL: {huggingface_slug}, weight name: {parsed_query_params['weight_name']}")
                     pipe.load_lora_weights(huggingface_slug, **parsed_query_params)
                 # Check for Civitai URL

--- a/predict.py
+++ b/predict.py
@@ -20,6 +20,7 @@ from transformers import CLIPImageProcessor
 from diffusers.pipelines.stable_diffusion.safety_checker import (
     StableDiffusionSafetyChecker
 )
+from urllib.parse import urlparse, parse_qs
 
 MAX_IMAGE_SIZE = 1440
 MODEL_CACHE = "FLUX.1-dev"
@@ -233,9 +234,13 @@ class Predictor(BasePredictor):
                 elif re.match(r"^https?://huggingface.co", hf_lora):
                     print(f"Downloading LoRA weights from - HF URL: {hf_lora}")
                     huggingface_slug = re.search(r"^https?://huggingface.co/([a-zA-Z0-9_-]+/[a-zA-Z0-9_-]+)", hf_lora).group(1)
-                    weight_name = hf_lora.split('/')[-1]
-                    print(f"HuggingFace slug from URL: {huggingface_slug}, weight name: {weight_name}")
-                    pipe.load_lora_weights(huggingface_slug, weight_name=weight_name)
+                    hf_lora_parsed = urlparse(hf_lora)
+                    parsed_query_params = parse_qs(hf_lora_parsed.query)
+                    if "weight_name" not in parsed_query_params:
+                        # Take weight name from last part of path
+                        parsed_query_params["weight_name"] = hf_lora_parsed.path.split('/')[-1]
+                    print(f"HuggingFace slug from URL: {huggingface_slug}, weight name: {parsed_query_params["weight_name"]}")
+                    pipe.load_lora_weights(huggingface_slug, **parsed_query_params)
                 # Check for Civitai URL
                 elif re.match(r"^https?://civitai.com/api/download/models/[0-9]+\?type=Model&format=SafeTensor", hf_lora):
                     # split url to get first part of the url, everythin before '?type'


### PR DESCRIPTION
Please let me know if you have any PR requests or things you'd like to be different.


This change allows a user to pass a custom `hf_access_token` with the hf_lora url in order to load a custom lora from a private repo.

It follows the existing url path match `^https?://huggingface.co` and extracts query parameters to pass directly to `pipe.load_lora_weights` This allows 
```
https://huggingface.co/<HF_SLUG>/<WEIGHTS_NAME>
https://huggingface.co/<HF_SLUG>?token=<INSERT_HF_ACCESS_TOKEN>&weight_name=<WEIGHTS_NAME>
https://huggingface.co/<HF_SLUG>/<WEIGHTS_NAME>?token=<INSERT_HF_ACCESS_TOKEN>
```
And other loading parameters to be specified keeping backwards compatibility.

Figured using the existing huggingface url match and url parsing would be a flexible way to pass anything to the load statement without changing anything else, but let me know if you'd like it done a different way