### PR TITLE
working poc hotswap for loras

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,3 +15,8 @@ __pycache__
 
 # Exclude Python virtual environment
 /venv
+
+safety-cache/
+weights-cache/
+FLUX.1-dev/
+*.png

--- a/hotswap.py
+++ b/hotswap.py
@@ -1,0 +1,196 @@
+# Copyright 2024-present the HuggingFace Inc. team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+from operator import attrgetter
+
+import torch
+
+from peft.config import PeftConfig
+from peft.mapping import PEFT_TYPE_TO_CONFIG_MAPPING
+
+
+from peft.utils.other import infer_device
+from peft.utils.peft_types import PeftType
+from peft.utils.save_and_load import load_peft_weights
+
+PEFT_TYPE_TO_PREFIX_MAPPING = {
+    PeftType.IA3: "ia3_",
+    PeftType.LORA: "lora_",
+    PeftType.ADALORA: "lora_",
+    PeftType.LOHA: "hada_",
+    PeftType.LOKR: "lokr_",
+    PeftType.OFT: "oft_",
+    PeftType.POLY: "poly_",
+    PeftType.BOFT: "boft_",
+    PeftType.LN_TUNING: "ln_tuning_",
+    PeftType.VERA: "vera_lambda_",
+    PeftType.FOURIERFT: "fourierft_",
+    PeftType.HRA: "hra_",
+    PeftType.VBLORA: "vblora_",
+}
+
+def _insert_adapter_name_into_state_dict(
+    state_dict: dict[str, torch.Tensor], adapter_name: str, parameter_prefix: str
+) -> dict[str, torch.Tensor]:
+    """Utility function to remap the state_dict keys to fit the PEFT model by inserting the adapter name."""
+    peft_model_state_dict = {}
+    for key, val in state_dict.items():
+        if parameter_prefix in key:
+            suffix = key.split(parameter_prefix)[1]
+            if "." in suffix:
+                suffix_to_replace = ".".join(suffix.split(".")[1:])
+                key = key.replace(suffix_to_replace, f"{adapter_name}.{suffix_to_replace}")
+            else:
+                key = f"{key}.{adapter_name}"
+            peft_model_state_dict[key] = val
+        else:
+            peft_model_state_dict[key] = val
+    return peft_model_state_dict
+
+
+def hotswap_adapter_from_state_dict(model, state_dict, adapter_name, parameter_prefix="lora_"):
+    """
+    Swap out the adapter weights from the model with the weights from state_dict.
+    As of now, only LoRA is supported.
+    This is a low-level function that assumes that the adapters have been checked for compatibility and that the
+    state_dict has been correctly mapped to work with PEFT. For a high level function that performs this work for you,
+    use `hotswap_adapter` instead.
+    Args:
+        model (`nn.Module`):
+            The model with the loaded adapter.
+        state_dict (`dict[str, torch.Tensor]`):
+            The state dict of the new adapter, which needs to be compatible (targeting same modules etc.).
+        adapter_name (`str`):
+            The name of the adapter that should be hot-swapped, e.g. `"default"`. The name will remain the same after
+            swapping.
+        parameter_prefix (`str`, *optional*, defaults to `"lora_"`)
+            The prefix used to identify the adapter's keys in the state dict. For LoRA, this would be `"lora_"` (the
+            default).
+    Raises:
+        RuntimeError
+            If the old and the new adapter are not compatible, a RuntimeError is raised.
+    """
+    # Ensure that all the keys of the new adapter correspond exactly to the keys of the old adapter, otherwise
+    # hot-swapping is not possible
+
+    is_compiled = hasattr(model, "_orig_mod")
+    # TODO: there is probably a more precise way to identify the adapter keys
+    missing_keys = {k for k in model.state_dict() if (parameter_prefix in k) and (adapter_name in k)}
+    unexpected_keys = set()
+
+    # first: dry run, not swapping anything
+    for key, new_val in state_dict.items():
+        key = key.removeprefix("transformer.") # TODO: this is but one of many state dict hacks; we'll need to establish some sort of pattern to remap here
+        try:
+            old_val = attrgetter(key)(model)
+        except AttributeError:
+            unexpected_keys.add(key)
+            continue
+
+        if is_compiled:
+            missing_keys.remove("_orig_mod." + key)
+        else:
+            missing_keys.remove(key)
+
+    if missing_keys or unexpected_keys:
+        msg = "Hot swapping the adapter did not succeed."
+        if missing_keys:
+            msg += f" Missing keys: {', '.join(sorted(missing_keys))}."
+        if unexpected_keys:
+            msg += f" Unexpected keys: {', '.join(sorted(unexpected_keys))}."
+        raise RuntimeError(msg)
+
+    # actual swapping
+    for key, new_val in state_dict.items():
+        key = key.removeprefix("transformer.") # TODO: see above
+        # no need to account for potential _orig_mod in key here, as torch handles that
+        old_val = attrgetter(key)(model)
+        if is_compiled:
+            # here we zero pad
+            old_val.data = new_val.data
+        else:
+            torch.utils.swap_tensors(old_val, new_val)
+
+
+def _check_hotswap_configs_compatible(config0: PeftConfig, config1: PeftConfig) -> None:
+    """
+    Check if two configs are compatible for hot-swapping.
+    Only LoRA parameters are checked for now.
+    To hot-swap two adapters, their configs must be compatible. Otherwise, the results could be false. E.g. if they use
+    different alpha values, after hot-swapping, the alphas from the first adapter would still be used with the weights
+    from the 2nd adapter, which would result in incorrect behavior. There is probably a way to swap these values as
+    well, but that's not implemented yet, and we need to be careful not to trigger re-compilation if the model is
+    compiled (so no modification of the dict).
+    """
+
+    if config0.peft_type != config1.peft_type:
+        msg = f"Incompatible PEFT types found: {config0.peft_type.value} and {config1.peft_type.value}"
+        raise ValueError(msg)
+
+    # TODO: This is a very rough check only for LoRA at the moment. Also, there might be some options that don't
+    # necessarily require an error.
+    config_keys_to_check = ["lora_alpha", "use_rslora", "lora_dropout", "alpha_pattern", "use_dora"]
+    config0 = config0.to_dict()
+    config1 = config1.to_dict()
+    sentinel = object()
+    for key in config_keys_to_check:
+        val0 = config0.get(key, sentinel)
+        val1 = config1.get(key, sentinel)
+        if val0 != val1:
+            raise ValueError(f"Configs are incompatible: for {key}, {val0} != {val1}")
+
+
+def hotswap_adapter(pipe, model_name_or_path, adapter_name, torch_device="cuda", **kwargs):
+    """Substitute old adapter data with new adapter data, keeping the rest the same.
+    As of now, only LoRA is supported.
+    This function is useful when you want to replace the loaded adapter with a new adapter. The adapter name will
+    remain the same, but the weights and other parameters will be swapped out.
+    If the adapters are incomptabile, e.g. targeting different layers or having different alpha values, an error will
+    be raised.
+    Args:
+        model ([`~PeftModel`]):
+            The PEFT model with the loaded adapter.
+        model_name_or_path (`str`):
+            The name or path of the model to load the new adapter from.
+        adapter_name (`str`):
+            The name of the adapter to swap, e.g. `"default"`. The name will stay the same after swapping.
+        torch_device: (`str`, *optional*, defaults to None):
+            The device to load the new adapter onto.
+        **kwargs (`optional`):
+            Additional keyword arguments used for loading the config and weights.
+    """
+
+    ############################
+
+    state_dict, alphas = pipe.lora_state_dict(model_name_or_path, return_alphas=True)
+    if alphas:
+        print("ignoring alphas! not that hard to unignore but that is a problem for The Future")
+
+    ###########################
+    # LOAD & REMAP STATE_DICT #
+    ###########################
+
+    parameter_prefix = "lora_"
+    peft_model_state_dict = _insert_adapter_name_into_state_dict(
+        state_dict, adapter_name=adapter_name, parameter_prefix=parameter_prefix
+    )
+
+    hotswap_adapter_from_state_dict(
+        model=pipe.transformer,
+        state_dict=peft_model_state_dict,
+        adapter_name=adapter_name,
+        parameter_prefix=parameter_prefix,
+    )
+

--- a/lora_loading_patch.py
+++ b/lora_loading_patch.py
@@ -1,4 +1,6 @@
 # ruff: noqa
+from typing import Dict, Union
+import torch 
 from diffusers.utils import (
     convert_unet_state_dict_to_peft,
     get_peft_kwargs,
@@ -7,8 +9,142 @@ from diffusers.utils import (
     logging,
 )
 
+from hotswap import rank_up_state_dict
+
 logger = logging.get_logger(__name__)
 
+
+def lora_state_dict(
+    cls,
+    pretrained_model_name_or_path_or_dict: Union[str, Dict[str, torch.Tensor]],
+    return_alphas: bool = False,
+    pad_rank: int = None,
+    **kwargs,
+):
+    r"""
+    Return state dict for lora weights and the network alphas.
+
+    <Tip warning={true}>
+
+    We support loading A1111 formatted LoRA checkpoints in a limited capacity.
+
+    This function is experimental and might change in the future.
+
+    </Tip>
+
+    Parameters:
+        pretrained_model_name_or_path_or_dict (`str` or `os.PathLike` or `dict`):
+            Can be either:
+
+                - A string, the *model id* (for example `google/ddpm-celebahq-256`) of a pretrained model hosted on
+                    the Hub.
+                - A path to a *directory* (for example `./my_model_directory`) containing the model weights saved
+                    with [`ModelMixin.save_pretrained`].
+                - A [torch state
+                    dict](https://pytorch.org/tutorials/beginner/saving_loading_models.html#what-is-a-state-dict).
+
+        cache_dir (`Union[str, os.PathLike]`, *optional*):
+            Path to a directory where a downloaded pretrained model configuration is cached if the standard cache
+            is not used.
+        force_download (`bool`, *optional*, defaults to `False`):
+            Whether or not to force the (re-)download of the model weights and configuration files, overriding the
+            cached versions if they exist.
+
+        proxies (`Dict[str, str]`, *optional*):
+            A dictionary of proxy servers to use by protocol or endpoint, for example, `{'http': 'foo.bar:3128',
+            'http://hostname': 'foo.bar:4012'}`. The proxies are used on each request.
+        local_files_only (`bool`, *optional*, defaults to `False`):
+            Whether to only load local model weights and configuration files or not. If set to `True`, the model
+            won't be downloaded from the Hub.
+        token (`str` or *bool*, *optional*):
+            The token to use as HTTP bearer authorization for remote files. If `True`, the token generated from
+            `diffusers-cli login` (stored in `~/.huggingface`) is used.
+        revision (`str`, *optional*, defaults to `"main"`):
+            The specific model version to use. It can be a branch name, a tag name, a commit id, or any identifier
+            allowed by Git.
+        subfolder (`str`, *optional*, defaults to `""`):
+            The subfolder location of a model file within a larger model repository on the Hub or locally.
+
+    """
+    # Load the main state dict first which has the LoRA layers for either of
+    # transformer and text encoder or both.
+    cache_dir = kwargs.pop("cache_dir", None)
+    force_download = kwargs.pop("force_download", False)
+    proxies = kwargs.pop("proxies", None)
+    local_files_only = kwargs.pop("local_files_only", None)
+    token = kwargs.pop("token", None)
+    revision = kwargs.pop("revision", None)
+    subfolder = kwargs.pop("subfolder", None)
+    weight_name = kwargs.pop("weight_name", None)
+    use_safetensors = kwargs.pop("use_safetensors", None)
+
+    allow_pickle = False
+    if use_safetensors is None:
+        use_safetensors = True
+        allow_pickle = True
+
+    user_agent = {
+        "file_type": "attn_procs_weights",
+        "framework": "pytorch",
+    }
+
+    state_dict = cls._fetch_state_dict(
+        pretrained_model_name_or_path_or_dict=pretrained_model_name_or_path_or_dict,
+        weight_name=weight_name,
+        use_safetensors=use_safetensors,
+        local_files_only=local_files_only,
+        cache_dir=cache_dir,
+        force_download=force_download,
+        proxies=proxies,
+        token=token,
+        revision=revision,
+        subfolder=subfolder,
+        user_agent=user_agent,
+        allow_pickle=allow_pickle,
+    )
+    is_dora_scale_present = any("dora_scale" in k for k in state_dict)
+    if is_dora_scale_present:
+        warn_msg = "It seems like you are using a DoRA checkpoint that is not compatible in Diffusers at the moment. So, we are going to filter out the keys associated to 'dora_scale` from the state dict. If you think this is a mistake please open an issue https://github.com/huggingface/diffusers/issues/new."
+        logger.warning(warn_msg)
+        state_dict = {k: v for k, v in state_dict.items() if "dora_scale" not in k}
+
+    # TODO (sayakpaul): to a follow-up to clean and try to unify the conditions.
+    is_kohya = any(".lora_down.weight" in k for k in state_dict)
+    if is_kohya:
+        state_dict = _convert_kohya_flux_lora_to_diffusers(state_dict)
+        # Kohya already takes care of scaling the LoRA parameters with alpha.
+        return (state_dict, None) if return_alphas else state_dict
+
+    is_xlabs = any("processor" in k for k in state_dict)
+    if is_xlabs:
+        state_dict = _convert_xlabs_flux_lora_to_diffusers(state_dict)
+        # xlabs doesn't use `alpha`.
+        return (state_dict, None) if return_alphas else state_dict
+
+    # For state dicts like
+    # https://huggingface.co/TheLastBen/Jon_Snow_Flux_LoRA
+    keys = list(state_dict.keys())
+    network_alphas = {}
+    for k in keys:
+        if "alpha" in k:
+            alpha_value = state_dict.get(k)
+            if (torch.is_tensor(alpha_value) and torch.is_floating_point(alpha_value)) or isinstance(
+                alpha_value, float
+            ):
+                network_alphas[k] = state_dict.pop(k)
+            else:
+                raise ValueError(
+                    f"The alpha key ({k}) seems to be incorrect. If you think this error is unexpected, please open as issue."
+                )
+    if pad_rank: 
+
+        state_dict = rank_up_state_dict(state_dict, pad_rank)
+
+
+    if return_alphas:
+        return state_dict, network_alphas
+    else:
+        return state_dict
 
 # patching inject_adapter_in_model and load_peft_state_dict with low_cpu_mem_usage=True until it's merged into diffusers
 def load_lora_into_transformer(

--- a/test_compiled_hotswap.py
+++ b/test_compiled_hotswap.py
@@ -1,0 +1,91 @@
+from predict import Predictor
+
+
+def test_compile_same_rank():
+    """
+    Runs a test with three different loras, all of which are the same rank. 
+    """
+    p = Predictor()
+    p.setup(compile=True)
+    p.predict(
+        "a photo of a TOK dog",
+        "1:1",
+        None,
+        None,
+        1,
+        28,
+        3.5,
+        1234,
+        "png",
+        80,
+        "https://replicate.delivery/yhqm/hNeuharNetjpfpHVlUyPs8O8kygdciYIi8dNzj3K5bT8xllmA/trained_model.tar",
+        1.1,
+        True
+    )
+    p.predict(
+        "a photo of a TOK dog",
+        "1:1",
+        None,
+        None,
+        1,
+        28,
+        3.5,
+        1234,
+        "png",
+        80,
+        "https://replicate.delivery/yhqm/0OmoRQJ60q6JOd6Fl9kIQ8P0W0vUQAMcu2s8uiSR8O5yJy0E/trained_model.tar",
+        1.1,
+        True
+    )
+    p.predict(
+        "SHPS, A hawaiian beach in the style of SHPS",
+        "1:1",
+        None,
+        None,
+        1,
+        28,
+        3.5,
+        1234,
+        "png",
+        80,
+        "https://replicate.delivery/yhqm/3iisiVryWZr4C1oaVHZys6Q8gIaGquFEpeHjc68wioMpzgqJA/trained_model.tar",
+        1.1,
+        True
+    )
+
+def test_compile_different_rank():
+    """
+    Runs a lora of rank 16 and then a lora of rank 64
+    """
+    p = Predictor()
+    p.setup(compile=True)
+    p.predict(
+        "a photo of a TOK dog",
+        "1:1",
+        None,
+        None,
+        1,
+        28,
+        3.5,
+        1234,
+        "png",
+        80,
+        "https://replicate.delivery/yhqm/hNeuharNetjpfpHVlUyPs8O8kygdciYIi8dNzj3K5bT8xllmA/trained_model.tar",
+        1.1,
+        True
+    )
+    p.predict(
+        "a photo of ZIKI in the forest",
+        "1:1",
+        None,
+        None,
+        1,
+        28,
+        3.5,
+        1234,
+        "png",
+        80,
+        "https://replicate.delivery/yhqm/IosLs4j02TKeQSSiA0DxEsLKuf3fu0iJVd9Eelmqynoxf6naC/trained_model.tar",
+        1.1,
+        True
+    )

--- a/test_compiled_hotswap.py
+++ b/test_compiled_hotswap.py
@@ -89,3 +89,6 @@ def test_compile_different_rank():
         1.1,
         True
     )
+
+if __name__ == '__main__': 
+    test_compile_different_rank()

--- a/weights.py
+++ b/weights.py
@@ -112,6 +112,10 @@ class WeightsDownloadCache:
         :param dest: Path to store weights file.
         :param file: If True, download the file as is, otherwise extract it.
         """
+        if os.path.exists(dest):
+            print("File exists on disk, assuming the cache was warmed")
+            return
+        
         print("Ensuring enough disk space...")
         while not self._has_enough_space() and len(self.lru_paths) > 0:
             self._remove_least_recent()


### PR DESCRIPTION
Just a draft PR for a poc of hotswapping, makes use of some wip work from diffusers. 

This will successfully hotswap a torch.compiled model up to some manually configured rank; atm I have it set to be the highest rank lora we support training. 

Caveats:
* not actively handling alpha - but then we don't store that
* for folks who only train subsets of all modules / different modules, we're not handling that here either. 